### PR TITLE
Fix doc credentials

### DIFF
--- a/src/main/java/com/vaultshield/passwordmanager/documentation/ExampleValues.java
+++ b/src/main/java/com/vaultshield/passwordmanager/documentation/ExampleValues.java
@@ -43,11 +43,9 @@ public class ExampleValues {
 
     public static final String STATUS_400_EMAIL = "Email already exists";
 
-    public static final String ACCOUNT = "Twitter";
+    public static final String ACCOUNT = "johndoe@email.com";
 
-    public static final String CRED_TITLE = "Social Media";
-
-    public static final String VALUE = "password123";
+    public static final String CRED_TITLE = "Twitter";
 
     public static final String NOTE = "This is a note";
 
@@ -58,5 +56,7 @@ public class ExampleValues {
     public static final String CRED_FAV = "true";
 
     public static final String CRED_GROUP = "null";
+
+    public static final String PASS_ID = "899eef8f-71c7-43a6-a91f-85398cbc5bf4";
 
 }

--- a/src/main/java/com/vaultshield/passwordmanager/mapper/CredentialMapper.java
+++ b/src/main/java/com/vaultshield/passwordmanager/mapper/CredentialMapper.java
@@ -4,11 +4,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.vaultshield.passwordmanager.models.entities.CredentialsEntity;
+import com.vaultshield.passwordmanager.models.entities.PasswordEntity;
 import com.vaultshield.passwordmanager.models.response.CredentialResponse;
+import com.vaultshield.passwordmanager.models.response.PasswordResponse;
 
 public class CredentialMapper {
 
     public static CredentialResponse toCredentialResponse(CredentialsEntity credential) {
+        PasswordResponse passwordResponse = null;
+        if (credential.getPassword() != null) {
+            PasswordEntity passwordEntity = credential.getPassword();
+            passwordResponse = PasswordMapper.toPasswordResponse(passwordEntity);
+        }
         return new CredentialResponse(
                 credential.getId(),
                 credential.getCredentialTypeId(),
@@ -19,7 +26,7 @@ public class CredentialMapper {
                 credential.getFavorite(),
                 credential.getGroupId(),
                 credential.getUser().getId(),
-                credential.getPassword().getId());
+                passwordResponse);
     }
 
     public static List<CredentialResponse> toCredentialResponseList(List<CredentialsEntity> credentials) {

--- a/src/main/java/com/vaultshield/passwordmanager/mapper/PasswordMapper.java
+++ b/src/main/java/com/vaultshield/passwordmanager/mapper/PasswordMapper.java
@@ -1,0 +1,16 @@
+package com.vaultshield.passwordmanager.mapper;
+
+import com.vaultshield.passwordmanager.models.entities.PasswordEntity;
+import com.vaultshield.passwordmanager.models.response.PasswordResponse;
+
+public class PasswordMapper {
+
+    public static PasswordResponse toPasswordResponse(PasswordEntity password) {
+        return new PasswordResponse(
+                password.getId(),
+                password.getTitle(),
+                password.getAccount(),
+                password.getPassword(),
+                password.getNote());
+    }
+}

--- a/src/main/java/com/vaultshield/passwordmanager/models/entities/PasswordEntity.java
+++ b/src/main/java/com/vaultshield/passwordmanager/models/entities/PasswordEntity.java
@@ -1,6 +1,12 @@
 package com.vaultshield.passwordmanager.models.entities;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,12 +19,11 @@ public class PasswordEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", nullable = false)
     private String id;
- //   @Column(name = "credentials_id")
- //   private String credentialsId;
     private String title;
     private String account;
     private String password;
     private String note;
+
     @OneToOne(targetEntity=CredentialsEntity.class)
     private CredentialsEntity credentials;
 

--- a/src/main/java/com/vaultshield/passwordmanager/models/response/CredentialResponse.java
+++ b/src/main/java/com/vaultshield/passwordmanager/models/response/CredentialResponse.java
@@ -41,7 +41,7 @@ public class CredentialResponse {
     @Schema(description = "User ID", example = ExampleValues.ID)
     private String userId;
 
-    @Schema(description = "Password ID", example = ExampleValues.ID)
-    private String passwordId;
+    @Schema(description = "Password details")
+    private PasswordResponse password;
 
 }

--- a/src/main/java/com/vaultshield/passwordmanager/models/response/PasswordResponse.java
+++ b/src/main/java/com/vaultshield/passwordmanager/models/response/PasswordResponse.java
@@ -1,0 +1,29 @@
+package com.vaultshield.passwordmanager.models.response;
+
+import com.vaultshield.passwordmanager.documentation.ExampleValues;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordResponse {
+
+    @Schema(description = "Password ID", example = ExampleValues.PASS_ID)
+    private String id;
+
+    @Schema(description = "Password title", example = ExampleValues.CRED_TITLE)
+    private String title;
+
+    @Schema(description = "User account for this password", example = ExampleValues.ACCOUNT)
+    private String account;
+
+    @Schema(description = "Password", example = ExampleValues.PASSWORD)
+    private String password;
+
+    @Schema(description = "Password note", example = ExampleValues.NOTE)
+    private String note;
+}

--- a/src/main/java/com/vaultshield/passwordmanager/services/impl/PasswordServiceImpl.java
+++ b/src/main/java/com/vaultshield/passwordmanager/services/impl/PasswordServiceImpl.java
@@ -26,7 +26,10 @@ public class PasswordServiceImpl implements PasswordService {
         PasswordEntity passwordEntity = new PasswordEntity();
         passwordEntity.setTitle(request.getTitle());
         passwordEntity.setAccount(request.getAccount());
-        passwordEntity.setPassword(bcrypt.encode(request.getPassword()));
+        // TODO: Encriptar password antes de guardarla en la base de datos
+        // No vale con bcrypt ya que tenemos que poder desencriptarla y mostrarla.
+        // passwordEntity.setPassword(bcrypt.encode(request.getPassword()));
+        passwordEntity.setPassword(request.getPassword());
         passwordEntity.setNote(request.getNote());
 
         return passwordRepository.save(passwordEntity);


### PR DESCRIPTION
## TICKET

<!-- Insertar el nombre de la tarea en los corchetes y el link de Trello en los paréntesis -->

- [Arreglar documentacion de credenciales](https://trello.com/c/Tx72mUf8/20-arreglar-documentacion-de-credenciales)

## Description

<!-- Describir la tarea -->

- Eliminar los campos innecesarios y arreglar los ejemplos de credenciales en la documentacion de Swagger.
- Se ha añadido toda la informacion del password en la respuesta a las peticiones de credenciales. Ya que antes estaba devolviendo solo el passwordID. De esta forma se tiene toda la info desde la misma petición.
- Se ha eliminado el bcrypt al guardar una nueva credencial en la base de datos y añadido un comentario TODO (ya que esta parte de encriptación es otra de las tareas y tendrá una PR independiente)
## Evidence:
Ejemplo de respuesta de credencial:
![image](https://github.com/VaultShield/backend/assets/90536006/d5450ba7-5d89-4d46-924a-a6d04c2251e0)

<!-- Añadir foto/video de la tarea realizada -->
