### PR TITLE
Fix: removed the Bearer header for recover token verify

### DIFF
--- a/src/main/java/com/vaultshield/passwordmanager/security/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/vaultshield/passwordmanager/security/jwt/JwtTokenUtil.java
@@ -129,12 +129,6 @@ public class JwtTokenUtil {
     }
 
     public String validateRecoverToken(String token){
-
-        if (!token.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Token does not contain 'Bearer' type");
-        }
-        token = token.substring(7);
-
         try {
             Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(getRecoverSingKey()).build().parseClaimsJws(token);
             Claims body = claims.getBody();

--- a/src/main/java/com/vaultshield/passwordmanager/services/impl/RecoverImpl.java
+++ b/src/main/java/com/vaultshield/passwordmanager/services/impl/RecoverImpl.java
@@ -1,6 +1,5 @@
 package com.vaultshield.passwordmanager.services.impl;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## TICKET

<!-- Insertar el nombre de la tarea en los corchetes y el link de Trello en los paréntesis -->

- [HOTFIX: fix verificacion de token sin Bearer en header](https://trello.com/c/YVM6ALma/59-hotfix-fix-verificacion-de-token-sin-bearer-en-header)

## Description

Hot fix verificacion Bearer en header token recover

## Evidence:

![image](https://github.com/VaultShield/backend/assets/53578660/0902e4f1-7e1d-4670-b4f9-e36c0d83436f)
